### PR TITLE
fix: check invoice date before sending to OBR

### DIFF
--- a/burundi_compliance/burundi_compliance/overrides/cancel_invoice.py
+++ b/burundi_compliance/burundi_compliance/overrides/cancel_invoice.py
@@ -19,13 +19,16 @@ auth_details = base.get_auth_details()
 
 
 def cancel_invoice(doc, method=None):
-    posting_date = ""
-    if isinstance(doc.posting_date, str):
-        posting_date = datetime.datetime.strptime(doc.posting_date, "%Y-%m-%d").date()
-    else:
-        posting_date = doc.posting_date
+    posting_date = doc.posting_date
+    start_date = auth_details.get("start_date")
 
-    if posting_date < auth_details.get("start_date"):
+    if isinstance(posting_date, str):
+        posting_date = datetime.datetime.strptime(doc.posting_date, "%Y-%m-%d").date()
+
+    if isinstance(start_date, str):
+        start_date = datetime.datetime.strptime(start_date, "%Y-%m-%d").date()
+
+    if posting_date < start_date:
         return
 
     invoice_data = get_invoice_data(doc)

--- a/burundi_compliance/burundi_compliance/overrides/sales_invoice.py
+++ b/burundi_compliance/burundi_compliance/overrides/sales_invoice.py
@@ -18,15 +18,6 @@ allow_obr_to_track_stock_movement = auth_details["allow_obr_to_track_stock_movem
 def on_submit(doc, method=None):
     obr_integration_base.authenticate()
 
-    posting_date = ""
-    if isinstance(doc.posting_date, str):
-        posting_date = datetime.datetime.strptime(doc.posting_date, "%Y-%m-%d").date()
-    else:
-        posting_date = doc.posting_date
-
-    if posting_date < auth_details.get("start_date"):
-        return
-
     if doc.doctype == "Sales Invoice" and doc.is_consolidated == 0:
         submit_invoice_request(doc)
     elif doc.doctype == "POS Invoice":
@@ -37,6 +28,18 @@ def on_submit(doc, method=None):
 
 
 def submit_invoice_request(doc):
+    posting_date = doc.posting_date
+    start_date = auth_details.get("start_date")
+
+    if isinstance(posting_date, str):
+        posting_date = datetime.datetime.strptime(doc.posting_date, "%Y-%m-%d").date()
+
+    if isinstance(start_date, str):
+        start_date = datetime.datetime.strptime(start_date, "%Y-%m-%d").date()
+
+    if posting_date < start_date:
+        return
+
     if allow_obr_to_track_sales == 1:
         sales_invoice_data_processor = InvoiceDataProcessor(doc)
 


### PR DESCRIPTION
Moved the logic that checks the invoice date before sending to OBR into the core function (submit_invoice_request) to prevent submission when the function is called via the scheduler.