### PR TITLE
fix(obr): invoice VAT from item-wise tax, stock sync, TIN verify, scheduler

### DIFF
--- a/burundi_compliance/burundi_compliance/apis/apis.py
+++ b/burundi_compliance/burundi_compliance/apis/apis.py
@@ -150,6 +150,12 @@ def confirm_tin(company: str, tin: str, doctype: str, docname: str):
 		obr_api.payload = payload
 		obr_api.service = "CheckTIN"
 		response = obr_api.make_remote_request(doctype, docname, require_handler=False)
+
+		if response and response.get("success") and doctype == "Customer":
+			frappe.db.set_value(
+				doctype, docname, "custom_tin_verified", True, update_modified=False
+			)
+
 		return response
 
 	return None

--- a/burundi_compliance/burundi_compliance/apis/utils/build_invoice_payload.py
+++ b/burundi_compliance/burundi_compliance/apis/utils/build_invoice_payload.py
@@ -1,4 +1,5 @@
 from bs4 import BeautifulSoup
+import re
 
 
 import frappe
@@ -149,26 +150,42 @@ def get_payment_method(payment_type: str) -> str:
 
 def get_invoice_items(doc):
 	items = []
-	itemised_tax_data = get_itemised_tax_breakup_data(doc)
+
+	item_wise_tax_details = frappe.get_all(
+		"Item Wise Tax Detail", filters={"parent": doc.name}, fields=["*"]
+	)
+
+	sales_taxes_and_charges = frappe.get_all(
+		"Sales Taxes and Charges",
+		filters={"parent": doc.name},
+		fields=["name", "account_head"],
+	)
+
+	stc_map = {stc.name: stc.account_head for stc in sales_taxes_and_charges}
+
+	tax_breakup_data = []
+	for tax in item_wise_tax_details:
+		account_head = stc_map.get(tax.tax_row)
+
+		if account_head:
+			tax_breakup_data.append({"account_head": account_head, **tax})
 
 	for item in doc.items:
-		tax_data = next(
-			(data for data in itemised_tax_data if data["item"] == item.item_code),
-			None,
-		)
+
+		item_taxes = [
+			tax for tax in tax_breakup_data if str(tax["item_row"]) == str(item.name)
+		]
+
 		total_vat = 0
 
-		if tax_data:
-			# Check if VAT exists, if not, check for other tax details
-			if "VAT" in tax_data:
-				total_vat = tax_data["VAT"]["tax_amount"]
-			else:
-				total_vat = 0
-		else:
-			total_vat = 0
+		for tax in item_taxes:
+			if re.search(r"\bVAT\b", tax.get("account_head", "") or "", re.IGNORECASE):
+				total_vat += tax.get("amount", 0)
+
 		item_designation = (
-			item.item_code + "-" + item.batch_no if item.batch_no else item.item_code
+			f"{item.item_code}-{item.batch_no}" if item.batch_no else item.item_code
 		)
+
 		items.append(
 			{
 				"item_code": item.item_code,
@@ -176,11 +193,71 @@ def get_invoice_items(doc):
 				"item_quantity": abs(item.qty),
 				"item_price": item.rate,
 				"item_total_amount": item.amount,
-				"vat": abs(int(total_vat)),
+				"vat": abs(total_vat),
 				"item_ct": "0",
 				"item_tl": "0",
-				"item_price_nvat": abs(int(item.amount)),
-				"item_price_wvat": abs(int(item.amount + total_vat)),
+				"item_price_nvat": abs(item.amount),
+				"item_price_wvat": abs(item.amount + total_vat),
 			}
 		)
+
 	return items
+
+	# for item in doc.items:
+	#     tax_data = next(
+	#         (data for data in itemised_tax_data if data["item"] == item.item_code),
+	#         None,
+	#     )
+	#     total_vat = 0
+
+	#     if tax_data:
+	#         # Check if VAT exists, if not, check for other tax details
+	#         if "VAT" in tax_data:
+	#             total_vat = tax_data["VAT"]["tax_amount"]
+	#         else:
+	#             total_vat = 0
+	#     else:
+	#         total_vat = 0
+	# item_designation = (
+	#     item.item_code + "-" + item.batch_no if item.batch_no else item.item_code
+	# )
+	# items.append(
+	#     {
+	#         "item_code": item.item_code,
+	#         "item_designation": item_designation,
+	#         "item_quantity": abs(item.qty),
+	#         "item_price": item.rate,
+	#         "item_total_amount": item.amount,
+	#         "vat": abs(int(total_vat)),
+	#         "item_ct": "0",
+	#         "item_tl": "0",
+	#         "item_price_nvat": abs(int(item.amount)),
+	#         "item_price_wvat": abs(int(item.amount + total_vat)),
+	#     }
+	# )
+	# return items
+
+
+# [
+#     {
+#         "account_head": "VAT - MS",
+#         "name": "de76jio985",
+#         "creation": datetime.datetime(2026, 4, 10, 13, 28, 58, 327608),
+#         "modified": datetime.datetime(2026, 4, 10, 13, 28, 58, 327608),
+#         "modified_by": "Administrator",
+#         "owner": "Administrator",
+#         "docstatus": 1,
+#         "idx": 1,
+#         "item_row": "ckl72qon67",
+#         "tax_row": "d9see3b9dc",
+#         "rate": 18.0,
+#         "amount": 180.0,
+#         "taxable_amount": 1000.0,
+#         "parent": "ABC-2026-04-10-00004",
+#         "parentfield": "item_wise_tax_details",
+#         "parenttype": "Sales Invoice",
+#     }
+# ]
+
+
+# wsl400038739100326

--- a/burundi_compliance/burundi_compliance/apis/utils/get_stock_ledger_data.py
+++ b/burundi_compliance/burundi_compliance/apis/utils/get_stock_ledger_data.py
@@ -12,7 +12,7 @@ def get_stock_ledger_data(doc):
 	item_code = doc.item_code
 	mov_doc = frappe.get_doc(voucher_type, voucher_no)
 
-	valuation_rate = doc.valuation_rate
+	valuation_rate = get_valuation_rate(voucher_type, mov_doc, item_code)
 
 	if voucher_type == "Stock Reconciliation":
 		mov_type, qty_diff, mov_desc = get_voucher_doc_details(doc)
@@ -38,7 +38,7 @@ def get_stock_ledger_data(doc):
 			else abs(float(doc.actual_qty))
 		),
 		"item_measurement_unit": doc.stock_uom,
-		"item_cost_price": int(valuation_rate),
+		"item_cost_price": abs(float(valuation_rate)),
 		"item_cost_price_currency": frappe.get_value(
 			"Company", doc.company, "default_currency"
 		),
@@ -101,6 +101,7 @@ def get_voucher_doc_details(doc):
 			) = get_item_movement_for_delivery_note_and_sale_invoice_on_submit_and_cancel(
 				doc, voucher_doc
 			)
+			return mov_type, mov_desc
 
 		case "Purchase Invoice":
 			voucher_doc = frappe.get_doc("Purchase Invoice", doc.voucher_no)
@@ -141,7 +142,7 @@ def get_stock_movement_type_for_stock_entry(doc, voucher_doc):
 	Get the stock movement type based on stock entry type and custom movement type
 	"""
 	entry_type = voucher_doc.stock_entry_type
-	custom_mov_type = voucher_doc.custom_movement_type
+	custom_mov_type = voucher_doc.custom_stock_movement_type
 
 	if (doc.actual_qty > 0 and entry_type in ["Material Receipt", "Manufacture"]) or (
 		doc.actual_qty < 0
@@ -266,7 +267,7 @@ def get_item_movement_for_delivery_note_and_sale_invoice_on_submit_and_cancel(
 	doc, voucher_doc
 ):
 	"""
-	Get the movement type for delivery note
+	Get the movement type for delivery note and sales invoice
 	"""
 	movement_description = "Normal Sale of Goods"
 	movement_type = "SN"
@@ -288,16 +289,16 @@ def get_stock_recon_movement_type(doc, voucher_doc):
 	"""
 	has_batch = check_if_item_has_batches(doc.item_code)
 	warehouse = doc.warehouse
-	if doc.purpose == "Opening Stock":
+	if voucher_doc.purpose == "Opening Stock":
 		for item in voucher_doc.items:
 			if item.item_code == doc.item_code and item.warehouse == warehouse:
 				quantity_difference = item.quantity_difference
-		if doc.is_cancelled == 0:
+		if voucher_doc.is_cancelled == 0:
 			movement_type = "EI"  # Opening Stock
 		else:
 			movement_type = "SAU"
 
-	elif doc.purpose == "Stock Reconciliation":
+	elif voucher_doc.purpose == "Stock Reconciliation":
 		for item in voucher_doc.items:
 			item_batch = None
 			if has_batch:

--- a/burundi_compliance/burundi_compliance/background_tasks/tasks.py
+++ b/burundi_compliance/burundi_compliance/background_tasks/tasks.py
@@ -16,7 +16,7 @@ from ..handlers.stock_movement import (
 )
 
 
-def send_sales_pending_sales_invoices() -> None:
+def send_pending_sales_invoices() -> None:
 	all_submitted_unsent: list[Document] = frappe.get_all(
 		"Sales Invoice",
 		{"docstatus": 1, "custom_submitted_to_obr": 0, "is_opening": "No"},
@@ -101,8 +101,7 @@ def send_stock_movement_to_obr() -> None:
 		.on(SLE.item_code == Item.item_code)
 		.select(SLE.name)
 		.where(
-			(SLE.custom_sent_to_obr == 0)
-			& (SLE.docstatus == 1)
+			(SLE.docstatus == 1)
 			& (SLE.custom_etracker == 0)
 			& (SLE.custom_queued == 0)
 			& (Item.custom_allow_obr_to_track_stock_movement == 1),
@@ -119,12 +118,12 @@ def send_stock_movement_to_obr() -> None:
 			company = sle_doc.company
 
 			if not frappe.db.exists(SETTINGS_DOCTYPE_NAME, company):
-				return
+				continue
 
 			settings_doc = frappe.get_doc(SETTINGS_DOCTYPE_NAME, company)
 
 			if not settings_doc.is_active or not settings_doc.allow_obr_to_track_stock_movement:
-				return
+				continue
 
 			posting_date, start_date = sle_doc.posting_date, settings_doc.start_date
 			if isinstance(posting_date, str):
@@ -133,7 +132,7 @@ def send_stock_movement_to_obr() -> None:
 				start_date = datetime.strptime(start_date, "%Y-%m-%d").date()
 
 			if posting_date < start_date:
-				return
+				continue
 
 			if sle_doc.custom_queued == 1:
 				continue

--- a/burundi_compliance/burundi_compliance/client_scripts/e_invoicing.js
+++ b/burundi_compliance/burundi_compliance/client_scripts/e_invoicing.js
@@ -1,50 +1,69 @@
-frappe.ui.form.on("Sales Invoice", {
-  refresh: function (frm) {
-    if (frm.doc.docstatus == 1) {
-      addInvoiceButtons(frm, "Sales Invoice");
+frappe.ui.form.on('Sales Invoice', {
+  onload: function (frm) {
+    if (frm.is_new()) {
+      frm.set_value('custom_submitted_to_obr', 0)
+      frm.set_value('custom_einvoice_signatures', '')
+      frm.set_value('custom_invoice_registered_no', '')
+      frm.set_value('custom_invoice_registered_date', '')
+      frm.set_value('custom_invoice_identifier', '')
     }
   },
-});
+  refresh: function (frm) {
+    if (frm.doc.docstatus == 1) {
+      addInvoiceButtons(frm, 'Sales Invoice')
+    }
+  },
+})
 
-frappe.ui.form.on("POS Invoice", {
-  refresh: function (frm) {
-    if (frm.doc.docstatus == 1) {
-      addInvoiceButtons(frm, "POS Invoice");
+frappe.ui.form.on('POS Invoice', {
+  onload: function (frm) {
+    if (frm.is_new()) {
+      frm.set_value('custom_submitted_to_obr', 0)
+      frm.set_value('custom_einvoice_signatures', '')
+      frm.set_value('custom_invoice_registered_no', '')
+      frm.set_value('custom_invoice_registered_date', '')
+      frm.set_value('custom_invoice_identifier', '')
     }
   },
-});
+
+  refresh: function (frm) {
+    if (frm.doc.docstatus == 1) {
+      addInvoiceButtons(frm, 'POS Invoice')
+    }
+  },
+})
 
 function addInvoiceButtons(frm, invoiceType) {
   if (frm.doc.custom_submitted_to_obr) {
     frm.add_custom_button(
-      __("Get Invoice"),
+      __('Get Invoice'),
       function () {
         callBackendFunction(
           frm,
-          "apis.apis.get_invoice_from_obr",
-          "GET",
-          __("Getting Invoice..."),
+          'apis.apis.get_invoice_from_obr',
+          'GET',
+          __('Getting Invoice...'),
           invoiceType
-        );
+        )
       },
-      __("eBIMS Actions")
-    );
+      __('eBIMS Actions')
+    )
   }
 
   if (!frm.doc.custom_einvoice_signatures) {
     frm.add_custom_button(
-      __("Re-Submit"),
+      __('Re-Submit'),
       function () {
         callBackendFunction(
           frm,
-          "apis.apis.resubmit_invoice_to_obr",
-          "POST",
-          __("Resubmitting Invoice..."),
+          'apis.apis.resubmit_invoice_to_obr',
+          'POST',
+          __('Resubmitting Invoice...'),
           invoiceType
-        );
+        )
       },
-      __("eBIMS Actions")
-    );
+      __('eBIMS Actions')
+    )
   }
 }
 
@@ -64,85 +83,85 @@ function callBackendFunction(
     },
     callback: function (response) {
       if (response) {
-        if (action === "GET") {
+        if (action === 'GET') {
           if (response.message) {
-            showInvoiceDetailsDialog(response.message.result);
+            showInvoiceDetailsDialog(response.message.result)
           } else {
-            frappe.msgprint(__("Failed to Retrieve Invoice details"));
+            frappe.msgprint(__('Failed to Retrieve Invoice details'))
           }
         }
 
-        if (action === "POST") {
-          frappe.msgprint(__("Invoice Resubmission has been Queued"));
+        if (action === 'POST') {
+          frappe.msgprint(__('Invoice Resubmission has been Queued'))
         }
       }
     },
     freeze: true,
-    freeze_message: freeze_message || __("Processing..."),
-  });
+    freeze_message: freeze_message || __('Processing...'),
+  })
 }
 
 function showInvoiceDetailsDialog(result) {
-  let invoice = result.invoices[0];
+  let invoice = result.invoices[0]
 
   let dialog = new frappe.ui.Dialog({
-    title: __("Invoice Retrieved successfully"),
+    title: __('Invoice Retrieved successfully'),
     fields: [
       {
-        label: __("Invoice Number"),
-        fieldname: "invoice_number",
-        fieldtype: "Data",
+        label: __('Invoice Number'),
+        fieldname: 'invoice_number',
+        fieldtype: 'Data',
         default: invoice.invoice_number,
         read_only: true,
       },
       {
-        label: __("Invoice Date"),
-        fieldname: "invoice_date",
-        fieldtype: "Data",
+        label: __('Invoice Date'),
+        fieldname: 'invoice_date',
+        fieldtype: 'Data',
         default: invoice.invoice_date,
         read_only: true,
       },
       {
-        label: __("TP Type"),
-        fieldname: "tp_type",
-        fieldtype: "Data",
+        label: __('TP Type'),
+        fieldname: 'tp_type',
+        fieldtype: 'Data',
         default: invoice.tp_type,
         read_only: true,
       },
       {
-        label: __("TP Name"),
-        fieldname: "tp_name",
-        fieldtype: "Data",
+        label: __('TP Name'),
+        fieldname: 'tp_name',
+        fieldtype: 'Data',
         default: invoice.tp_name,
         read_only: true,
       },
       {
-        label: __("TP TIN"),
-        fieldname: "tp_TIN",
-        fieldtype: "Data",
+        label: __('TP TIN'),
+        fieldname: 'tp_TIN',
+        fieldtype: 'Data',
         default: invoice.tp_TIN,
         read_only: true,
       },
       {
-        label: __("Customer Name"),
-        fieldname: "customer_name",
-        fieldtype: "Data",
+        label: __('Customer Name'),
+        fieldname: 'customer_name',
+        fieldtype: 'Data',
         default: invoice.customer_name,
         read_only: true,
       },
       {
-        label: __("Customer TIN"),
-        fieldname: "customer_TIN",
-        fieldtype: "Data",
+        label: __('Customer TIN'),
+        fieldname: 'customer_TIN',
+        fieldtype: 'Data',
         default: invoice.customer_TIN,
         read_only: true,
       },
     ],
-  });
+  })
 
-  dialog.set_primary_action(__("Close"), function () {
-    dialog.hide();
-  });
+  dialog.set_primary_action(__('Close'), function () {
+    dialog.hide()
+  })
 
-  dialog.show();
+  dialog.show()
 }

--- a/burundi_compliance/burundi_compliance/handlers/stock_movement.py
+++ b/burundi_compliance/burundi_compliance/handlers/stock_movement.py
@@ -5,11 +5,9 @@ def handle_stock_ledger_entry_submission(
 	response: dict, document_name: str, doctype: str
 ) -> None:
 	try:
-		data_to_update = {
-			"custom_sent_to_obr": 1,
-		}
+		data_to_update = {}
 		if doctype == "Stock Ledger Entry":
-			data_to_update["custom_etracker"] = 1
+			data_to_update.setdefault("custom_etracker", 1)
 
 		frappe.db.set_value(doctype, document_name, data_to_update)
 		frappe.db.commit()

--- a/burundi_compliance/burundi_compliance/overrides/sales_invoice.py
+++ b/burundi_compliance/burundi_compliance/overrides/sales_invoice.py
@@ -155,10 +155,6 @@ def on_cancel(doc: Document, method: str | None = None) -> None:
 		)
 
 
-def handler(response, document_name, doctype):
-	pass
-
-
 def before_save(doc: Document, method: str | None = None) -> None:
 	if doc.is_return:
 		data_to_update = {

--- a/burundi_compliance/hooks.py
+++ b/burundi_compliance/hooks.py
@@ -184,7 +184,7 @@ doc_events = {
 scheduler_events = {
 	"cron": {
 		"*/5 * * * *": [
-			"burundi_compliance.burundi_compliance.utils.schedular.check_and_send_pending_stock_ledger_entry"
+			"burundi_compliance.burundi_compliance.background_tasks.tasks.send_stock_movement_to_obr"
 		],
 		# "*/15 * * * *": [
 		#     # "burundi_compliance.burundi_compliance.utils.schedular.check_and_send_pending_sales_invoices"
@@ -197,7 +197,7 @@ scheduler_events = {
 		# ],
 	},
 	"hourly": [
-		"burundi_compliance.burundi_compliance.background_tasks.tasks.send_sales_pending_sales_invoices",
+		"burundi_compliance.burundi_compliance.background_tasks.tasks.send_pending_sales_invoices",
 		"burundi_compliance.burundi_compliance.background_tasks.tasks.send_pending_pos_invoices",
 		"burundi_compliance.burundi_compliance.background_tasks.tasks.send_pending_cancelled_sales_invoices",
 		"burundi_compliance.burundi_compliance.background_tasks.tasks.send_pending_cancelled_pos_invoices",


### PR DESCRIPTION


Recompute invoice line VAT for OBR payloads using Item Wise Tax Detail rows joined to Sales Taxes and Charges, matching VAT by account head (regex) and using precise amounts instead of int-cast totals.

- API: after a successful Check TIN call for Customer, persist custom_tin_verified.

- Stock ledger → OBR: derive cost from voucher line valuation/rate via get_valuation_rate; send abs(float) as item_cost_price; read Stock Entry movement type from custom_stock_movement_type; fix Sales Invoice branch to return movement details; use voucher purpose (not SLE) for Stock Reconciliation opening vs reconciliation logic.

- Background jobs: rename send_sales_pending_sales_invoices to send_pending_sales_invoices; run stock movements from cron via send_stock_movement_to_obr (replacing schedular wrapper); drop custom_sent_to_obr from the SLE selection query; use continue instead of return inside the per-SLE loop so one failure/skip does not abort the batch.

- Stock movement success handler: only set custom_etracker on success (stop setting custom_sent_to_obr there).

- Client: on new Sales/POS Invoice, clear OBR/e-invoice fields so copies do not inherit stale identifiers; minor JS style (quotes/trailing commas).

- hooks: point cron at send_stock_movement_to_obr; update hourly job path for renamed pending-sales task.