### PR TITLE
fix: correct item VAT payload logic

### DIFF
--- a/burundi_compliance/burundi_compliance/doctype/ebms_settings/ebms_settings.json
+++ b/burundi_compliance/burundi_compliance/doctype/ebms_settings/ebms_settings.json
@@ -323,19 +323,19 @@
    "fieldname": "invoice_start_time",
    "fieldtype": "Time",
    "label": "Start Time",
-   "mandatory_depends_on": "eval:doc.limit_timeslot_for_invoice_posting===1;"
+   "mandatory_depends_on": "eval:doc.limit_invoice_posting_timeslot===1;"
   },
   {
    "fieldname": "stock_start_time",
    "fieldtype": "Time",
    "label": "Start Time",
-   "mandatory_depends_on": "eval:doc.limit_timeslot_for_stock_posting===1;"
+   "mandatory_depends_on": "eval:doc.limit_stock_posting_timeslot===1;"
   },
   {
    "fieldname": "invoice_end_time",
    "fieldtype": "Time",
    "label": "End Time",
-   "mandatory_depends_on": "eval:doc.limit_timeslot_for_invoice_posting===1;"
+   "mandatory_depends_on": "eval:doc.limit_invoice_posting_timeslot===1;"
   },
   {
    "fieldname": "column_break_tqil",
@@ -345,7 +345,7 @@
    "fieldname": "stock_end_time",
    "fieldtype": "Time",
    "label": "End Time",
-   "mandatory_depends_on": "eval:doc.limit_timeslot_for_stock_posting===1;"
+   "mandatory_depends_on": "eval:doc.limit_stock_posting_timeslot===1;"
   },
   {
    "fieldname": "limits_dont_apply_on_invoice",
@@ -374,7 +374,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-28 20:27:10.375845",
+ "modified": "2026-04-29 17:23:37.144493",
  "modified_by": "Administrator",
  "module": "Burundi Compliance",
  "name": "eBMS Settings",

--- a/burundi_compliance/burundi_compliance/utils/build_invoice_payload.py
+++ b/burundi_compliance/burundi_compliance/utils/build_invoice_payload.py
@@ -155,31 +155,16 @@ def get_invoice_items(doc):
 		"Item Wise Tax Detail", filters={"parent": doc.name}, fields=["*"]
 	)
 
-	sales_taxes_and_charges = frappe.get_all(
-		"Sales Taxes and Charges",
-		filters={"parent": doc.name},
-		fields=["name", "account_head"],
-	)
-
-	stc_map = {stc.name: stc.account_head for stc in sales_taxes_and_charges}
-
-	tax_breakup_data = []
-	for tax in item_wise_tax_details:
-		account_head = stc_map.get(tax.tax_row)
-
-		if account_head:
-			tax_breakup_data.append({"account_head": account_head, **tax})
-
 	for item in doc.items:
 
 		item_taxes = [
-			tax for tax in tax_breakup_data if str(tax["item_row"]) == str(item.name)
+			tax for tax in item_wise_tax_details if str(tax["item_row"]) == str(item.name)
 		]
 
 		total_vat = 0
 
 		for tax in item_taxes:
-			if re.search(r"\bVAT\b", tax.get("account_head", "") or "", re.IGNORECASE):
+			if tax.get("rate", 0) > 0:
 				total_vat += tax.get("amount", 0)
 
 		item_designation = (
@@ -188,18 +173,21 @@ def get_invoice_items(doc):
 			else (f"{item.item_code}-{item.batch_no}" if item.batch_no else item.item_code)
 		)
 
+		total_vat = abs(total_vat)
+		item_amount = abs(item.amount)
+
 		items.append(
 			{
 				"item_code": item.item_code,
 				"item_designation": item_designation,
 				"item_quantity": abs(item.qty),
 				"item_price": item.rate,
-				"item_total_amount": item.amount,
-				"vat": abs(total_vat),
+				"item_total_amount": item_amount,
+				"vat": total_vat,
 				"item_ct": "0",
 				"item_tl": "0",
-				"item_price_nvat": abs(item.amount),
-				"item_price_wvat": abs(item.amount + total_vat),
+				"item_price_nvat": item_amount,
+				"item_price_wvat": item_amount + total_vat,
 			}
 		)
 


### PR DESCRIPTION
- Refactor invoice payload item tax computation to derive VAT directly from positive item tax rates (instead of VAT account-head name matching), and normalize item amount/VAT values with absolute totals for payload consistency.