### PR TITLE
fix(obr): material transfer skip, and entry type purpose

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ fail_fast: false
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         files: 'burundi_compliance.*'
@@ -15,11 +15,18 @@ repos:
       - id: check-merge-conflict
       - id: check-ast
 
-  - repo: https://github.com/adityahase/black
-    rev: 9cb0a69f4d0030cdf687eddf314468b39ed54119
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.10
     hooks:
-      - id: black
-        additional_dependencies: ['click==8.0.4']
+      - id: ruff
+        name: 'Run ruff import sorter'
+        args: ['--select=I', '--fix']
+
+      - id: ruff
+        name: 'Run ruff linter'
+
+      - id: ruff-format
+        name: 'Run ruff formatter'
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1

--- a/burundi_compliance/burundi_compliance/background_tasks/stock_movement.py
+++ b/burundi_compliance/burundi_compliance/background_tasks/stock_movement.py
@@ -2,130 +2,148 @@ from datetime import datetime
 
 import frappe
 
-
-from ..utils.get_stock_ledger_data import get_stock_ledger_data
-from ..doctype.doctype_names_mapping import SETTINGS_DOCTYPE_NAME
-from ..utils.build_headers import build_headers
-from ..utils.utils import get_urls, in_configured_timeslot
 from ..apis.api_builder import OBRAPI
+from ..doctype.doctype_names_mapping import SETTINGS_DOCTYPE_NAME
 from ..handlers.stock_movement import (
-	handle_stock_ledger_entry_submission,
-	handle_stock_ledger_entry_failure,
+    handle_stock_ledger_entry_failure,
+    handle_stock_ledger_entry_submission,
 )
+from ..utils.build_headers import build_headers
+from ..utils.get_stock_ledger_data import get_stock_ledger_data
+from ..utils.utils import get_urls, in_configured_timeslot
 
 
 def send_stock_movement_to_obr() -> None:
-	# Get all stock ledger entries not sent to OBR - use SQL query to join items and check if it's being tracked
-	SLE = frappe.qb.DocType("Stock Ledger Entry")
-	Item = frappe.qb.DocType("Item")
-	query = (
-		frappe.qb.from_(SLE)
-		.join(Item)
-		.on(SLE.item_code == Item.item_code)
-		.select(SLE.name, SLE.company)
-		.where(
-			(SLE.docstatus == 1)
-			& (SLE.custom_etracker == 0)
-			& (SLE.custom_queued == 0)
-			& (Item.custom_allow_obr_to_track_stock_movement == 1),
-		)
-	)
+    # Get all stock ledger entries not sent to OBR - use SQL query to join items and check if it's being tracked
+    SLE = frappe.qb.DocType("Stock Ledger Entry")
+    Item = frappe.qb.DocType("Item")
+    query = (
+        frappe.qb.from_(SLE)
+        .join(Item)
+        .on(SLE.item_code == Item.item_code)
+        .select(SLE.name, SLE.company)
+        .where(
+            (SLE.docstatus == 1)
+            & (SLE.custom_etracker == 0)
+            & (SLE.custom_queued == 0)
+            & (Item.custom_allow_obr_to_track_stock_movement == 1),
+        )
+    )
 
-	stock_ledger_entries = query.run(as_dict=True)
+    stock_ledger_entries = query.run(as_dict=True)
 
-	if not stock_ledger_entries:
-		return
+    if not stock_ledger_entries:
+        return
 
-	entries_by_company = {}
-	for sle in stock_ledger_entries:
-		company = sle.company
-		if company not in entries_by_company:
-			entries_by_company[company] = []
-		entries_by_company[company].append(sle)
+    entries_by_company = {}
+    for sle in stock_ledger_entries:
+        company = sle.company
+        if company not in entries_by_company:
+            entries_by_company[company] = []
+        entries_by_company[company].append(sle)
 
-	for company, entries in entries_by_company.items():
-		if not frappe.db.exists(SETTINGS_DOCTYPE_NAME, company):
-			continue
+    for company, entries in entries_by_company.items():
+        if not frappe.db.exists(SETTINGS_DOCTYPE_NAME, company):
+            continue
 
-		settings_doc = frappe.get_doc(SETTINGS_DOCTYPE_NAME, company)
+        settings_doc = frappe.get_doc(SETTINGS_DOCTYPE_NAME, company)
 
-		if not settings_doc.is_active or not settings_doc.allow_obr_to_track_stock_movement:
-			continue
+        if not (
+            settings_doc.is_active and settings_doc.allow_obr_to_track_stock_movement
+        ):
+            continue
 
-		if not in_configured_timeslot(settings_doc, "stock"):
-			continue
+        if not in_configured_timeslot(settings_doc, "stock"):
+            continue
 
-		start_date = settings_doc.start_date
+        start_date = settings_doc.start_date
 
-		if isinstance(start_date, str):
-			start_date = datetime.strptime(start_date, "%Y-%m-%d").date()
+        if isinstance(start_date, str):
+            start_date = datetime.strptime(start_date, "%Y-%m-%d").date()
 
-		environment = "sandbox" if settings_doc.sandbox else "production"
-		request_url, server_url = get_urls(environment, "add_stock_movement")
+        environment = "sandbox" if settings_doc.sandbox else "production"
+        request_url, server_url = get_urls(environment, "add_stock_movement")
 
-		for sle_entry in entries:
-			try:
-				sle_doc = frappe.get_doc("Stock Ledger Entry", sle_entry.name)
-				posting_date = sle_doc.posting_date
+        for sle_entry in entries:
+            try:
+                sle_doc = frappe.get_doc("Stock Ledger Entry", sle_entry.name)
+                posting_date = sle_doc.posting_date
 
-				if isinstance(posting_date, str):
-					posting_date = datetime.strptime(posting_date, "%Y-%m-%d").date()
+                if isinstance(posting_date, str):
+                    posting_date = datetime.strptime(posting_date, "%Y-%m-%d").date()
 
-				if posting_date < start_date:
-					continue
+                if posting_date < start_date:
+                    continue
 
-				if sle_doc.custom_queued == 1:
-					continue
+                if sle_doc.custom_queued == 1:
+                    continue
 
-				# Check if it's a material transfer, if yes, skip
-				if (
-					sle_doc.voucher_type == "Stock Entry"
-					and frappe.get_doc("Stock Entry", sle_doc.voucher_no).stock_entry_type
-					== "Material Transfer"
-				):
-					continue
+                # Check if it's a material transfer, if yes, skip
+                # if (
+                #     sle_doc.voucher_type == "Stock Entry"
+                #     and frappe.get_doc(
+                #         "Stock Entry", sle_doc.voucher_no
+                #     ).stock_entry_type
+                #     == "Material Transfer"
+                # ):
+                if (
+                    sle_doc.voucher_type == "Stock Entry"
+                    and frappe.db.get_value(
+                        "Stock Entry Type",
+                        frappe.db.get_value(
+                            "Stock Entry",
+                            sle_doc.voucher_no,
+                            "stock_entry_type",
+                        ),
+                        "purpose",
+                    )
+                    == "Material Transfer"
+                ):
+                    continue
 
-				if (
-					sle_doc.voucher_type == "Stock Reconciliation"
-					and sle_doc.has_batch_no == 1
-					and sle_doc.actual_qty < 0
-				):
-					continue
+                if (
+                    sle_doc.voucher_type == "Stock Reconciliation"
+                    and sle_doc.has_batch_no == 1
+                    and sle_doc.actual_qty < 0
+                ):
+                    continue
 
-				sle_data = get_stock_ledger_data(sle_doc)
+                sle_data = get_stock_ledger_data(sle_doc)
 
-				if not sle_data:
-					continue
+                if not sle_data:
+                    continue
 
-				headers = build_headers(company)
+                headers = build_headers(company)
 
-				if headers and server_url and request_url:
-					url = f"{server_url}/{request_url}"
-					payload = sle_data
+                if headers and server_url and request_url:
+                    url = f"{server_url}/{request_url}"
+                    payload = sle_data
 
-					obr_api = OBRAPI()
-					obr_api.headers = headers
-					obr_api.url = url
-					obr_api.method = "POST"
-					obr_api.payload = payload
-					obr_api.service = "AddStockMovement"
-					obr_api.success_callback_handler = handle_stock_ledger_entry_submission
-					obr_api.error_callback_handler = handle_stock_ledger_entry_failure
+                    obr_api = OBRAPI()
+                    obr_api.headers = headers
+                    obr_api.url = url
+                    obr_api.method = "POST"
+                    obr_api.payload = payload
+                    obr_api.service = "AddStockMovement"
+                    obr_api.success_callback_handler = (
+                        handle_stock_ledger_entry_submission
+                    )
+                    obr_api.error_callback_handler = handle_stock_ledger_entry_failure
 
-					frappe.enqueue(
-						obr_api.make_remote_request,
-						is_async=True,
-						queue="default",
-						timeout=600,
-						job_name=f"obr_stock_movement_submission_{sle_doc.name}",
-						doctype="Stock Ledger Entry",
-						document_name=sle_doc.name,
-					)
+                    frappe.enqueue(
+                        obr_api.make_remote_request,
+                        is_async=True,
+                        queue="default",
+                        timeout=600,
+                        job_name=f"obr_stock_movement_submission_{sle_doc.name}",
+                        doctype="Stock Ledger Entry",
+                        document_name=sle_doc.name,
+                    )
 
-					sle_doc.db_set("custom_queued", 1)
-			except Exception:
-				frappe.log_error(
-					frappe.get_traceback(),
-					"Error in sending stock ledger entry {0}".format(sle.name),
-				)
-				continue
+                    sle_doc.db_set("custom_queued", 1)
+            except Exception:
+                frappe.log_error(
+                    frappe.get_traceback(),
+                    "Error in sending stock ledger entry {0}".format(sle.name),
+                )
+                continue

--- a/burundi_compliance/burundi_compliance/handlers/stock_movement.py
+++ b/burundi_compliance/burundi_compliance/handlers/stock_movement.py
@@ -2,32 +2,32 @@ import frappe
 
 
 def handle_stock_ledger_entry_submission(
-	response: dict, document_name: str, doctype: str
+    response: dict, document_name: str, doctype: str
 ) -> None:
-	try:
-		data_to_update = {
-			"custom_queued": 1,
-		}
-		if doctype == "Stock Ledger Entry":
-			data_to_update.setdefault("custom_etracker", 1)
+    try:
+        data_to_update = {
+            "custom_queued": 0,
+        }
+        if doctype == "Stock Ledger Entry":
+            data_to_update.setdefault("custom_etracker", 1)
 
-		frappe.db.set_value(doctype, document_name, data_to_update)
-		frappe.db.commit()
+        frappe.db.set_value(doctype, document_name, data_to_update)
+        frappe.db.commit()
 
-	except Exception as e:
-		frappe.log_error(f"Error updating {doctype} {document_name}: {str(e)}")
+    except Exception as e:
+        frappe.log_error(f"Error updating {doctype} {document_name}: {str(e)}")
 
 
 def handle_stock_ledger_entry_failure(
-	response: dict, document_name: str, doctype: str
+    response: dict, document_name: str, doctype: str
 ) -> None:
-	try:
-		data_to_update = {
-			"custom_queued": 0,
-		}
+    try:
+        data_to_update = {
+            "custom_queued": 0,
+        }
 
-		frappe.db.set_value(doctype, document_name, data_to_update)
-		frappe.db.commit()
+        frappe.db.set_value(doctype, document_name, data_to_update)
+        frappe.db.commit()
 
-	except Exception as e:
-		frappe.log_error(f"Error updating {doctype} {document_name}: {str(e)}")
+    except Exception as e:
+        frappe.log_error(f"Error updating {doctype} {document_name}: {str(e)}")

--- a/burundi_compliance/burundi_compliance/patches/delete_old_custom_fields.py
+++ b/burundi_compliance/burundi_compliance/patches/delete_old_custom_fields.py
@@ -1,0 +1,43 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import delete_custom_fields
+
+FIELDS_TO_DELETE = {
+    "Sales Invoice": [
+        "custom_etracker",
+        "custom_differ_submission_to_obr",
+    ],
+    "POS Invoice": ["custom_etracker", "custom_differ_submission_to_obr"],
+    "Delivery Note": [
+        "custom_etracker",
+    ],
+    "Purchase Receipt": [
+        "custom_etracker",
+    ],
+    "Purchase Invoice": [
+        "custom_etracker",
+    ],
+    "Stock Reconciliation": [
+        "custom_etracker",
+    ],
+    "Stock Entry": [
+        "custom_etracker",
+    ],
+}
+
+
+def execute():
+    for doctype, fields in FIELDS_TO_DELETE.items():
+        existing_fields = [
+            field
+            for field in fields
+            if frappe.db.exists(
+                "Custom Field",
+                {
+                    "dt": doctype,
+                    "fieldname": field,
+                },
+            )
+        ]
+
+        if existing_fields:
+            delete_custom_fields(doctype, existing_fields)

--- a/burundi_compliance/burundi_compliance/utils/get_stock_ledger_data.py
+++ b/burundi_compliance/burundi_compliance/utils/get_stock_ledger_data.py
@@ -1,411 +1,421 @@
 import frappe
-from .format_date_and_time import date_time_format
-from ..doctype.doctype_names_mapping import SETTINGS_DOCTYPE_NAME
-
 from frappe import _
+
+from ..doctype.doctype_names_mapping import SETTINGS_DOCTYPE_NAME
+from .format_date_and_time import date_time_format
 
 
 def get_stock_ledger_data(doc):
-	"""
-	Prepare data from stock ledger entry for further processing
-	"""
-	voucher_type = doc.voucher_type
-	voucher_no = doc.voucher_no
-	item_code = doc.item_code
-	mov_doc = frappe.get_doc(voucher_type, voucher_no)
+    """
+    Prepare data from stock ledger entry for further processing
+    """
+    voucher_type = doc.voucher_type
+    voucher_no = doc.voucher_no
+    item_code = doc.item_code
+    mov_doc = frappe.get_doc(voucher_type, voucher_no)
 
-	valuation_rate = get_valuation_rate(voucher_type, mov_doc, item_code)
+    valuation_rate = get_valuation_rate(voucher_type, mov_doc, item_code)
 
-	if voucher_type == "Stock Reconciliation":
-		mov_type, qty_diff, mov_desc = get_voucher_doc_details(doc)
-	else:
-		mov_type, mov_desc = get_voucher_doc_details(doc)
+    if voucher_type == "Stock Reconciliation":
+        mov_type, qty_diff, mov_desc = get_voucher_doc_details(doc)
+    else:
+        mov_type, mov_desc = get_voucher_doc_details(doc)
 
-	date = date_time_format(doc)
-	formatted_date = date[0]
+    date = date_time_format(doc)
+    formatted_date = date[0]
 
-	item_mov_inv_ref = get_invoice_reference_number(doc)
+    item_mov_inv_ref = get_invoice_reference_number(doc)
 
-	item_designation = create_item_designation(mov_doc, item_code)
+    item_designation = create_item_designation(mov_doc, item_code)
 
-	system_tax_id = get_system_tax_id(doc)
+    system_tax_id = get_system_tax_id(doc)
 
-	data = {
-		"system_or_device_id": system_tax_id,
-		"item_code": doc.item_code,
-		"item_designation": item_designation,
-		"item_quantity": (
-			abs(float(qty_diff))
-			if voucher_type == "Stock Reconciliation"
-			else abs(float(doc.actual_qty))
-		),
-		"item_measurement_unit": doc.stock_uom,
-		"item_cost_price": abs(float(valuation_rate)),
-		"item_cost_price_currency": frappe.get_value(
-			"Company", doc.company, "default_currency"
-		),
-		"item_movement_type": mov_type,
-		"item_movement_invoice_ref": item_mov_inv_ref,
-		"item_movement_description": mov_desc,
-		"item_movement_date": formatted_date,
-	}
+    data = {
+        "system_or_device_id": system_tax_id,
+        "item_code": doc.item_code,
+        "item_designation": item_designation,
+        "item_quantity": (
+            abs(float(qty_diff))
+            if voucher_type == "Stock Reconciliation"
+            else abs(float(doc.actual_qty))
+        ),
+        "item_measurement_unit": doc.stock_uom,
+        "item_cost_price": abs(float(valuation_rate)),
+        "item_cost_price_currency": frappe.get_value(
+            "Company", doc.company, "default_currency"
+        ),
+        "item_movement_type": mov_type,
+        "item_movement_invoice_ref": item_mov_inv_ref,
+        "item_movement_description": mov_desc,
+        "item_movement_date": formatted_date,
+    }
 
-	return data
+    return data
 
 
 def get_valuation_rate(voucher_type, doc, item_code):
-	"""
-	Get the valuation rate for the item for Stock Reconciliation,
-	Purchase Receipt, Delivery Note, Sales Invoice, Purchase Invoice
-	"""
-	for item in doc.items:
-		if item.item_code == item_code:
-			if voucher_type == "Stock Entry" or voucher_type == "Stock Reconciliation":
-				return item.valuation_rate
-			else:
-				return item.rate
+    """
+    Get the valuation rate for the item for Stock Reconciliation,
+    Purchase Receipt, Delivery Note, Sales Invoice, Purchase Invoice
+    """
+    for item in doc.items:
+        if item.item_code == item_code:
+            if voucher_type == "Stock Entry" or voucher_type == "Stock Reconciliation":
+                return item.valuation_rate
+            else:
+                return item.rate
 
 
 def get_voucher_doc_details(doc):
-	"""
-	Get the movement type, quantity difference and movement description for Stock Reconciliation
-	"""
-	match doc.voucher_type:
-		case "Stock Entry":
-			voucher_doc = frappe.get_doc("Stock Entry", doc.voucher_no)
-			mov_type = get_stock_movement_type_for_stock_entry(doc, voucher_doc)
-			mov_desc = get_stock_movement_description(voucher_doc)
-			return mov_type, mov_desc
+    """
+    Get the movement type, quantity difference and movement description for Stock Reconciliation
+    """
+    match doc.voucher_type:
+        case "Stock Entry":
+            voucher_doc = frappe.get_doc("Stock Entry", doc.voucher_no)
+            mov_type = get_stock_movement_type_for_stock_entry(doc, voucher_doc)
+            mov_desc = get_stock_movement_description(voucher_doc)
+            return mov_type, mov_desc
 
-		case "Purchase Receipt":
-			voucher_doc = frappe.get_doc("Purchase Receipt", doc.voucher_no)
-			mov_type = get_item_movement_for_purchase_receipt_and_invoice_on_submit_and_cancel(
-				doc, voucher_doc
-			)
+        case "Purchase Receipt":
+            voucher_doc = frappe.get_doc("Purchase Receipt", doc.voucher_no)
+            mov_type = (
+                get_item_movement_for_purchase_receipt_and_invoice_on_submit_and_cancel(
+                    doc, voucher_doc
+                )
+            )
 
-			mov_desc = get_stock_movement_description(voucher_doc)
+            mov_desc = get_stock_movement_description(voucher_doc)
 
-			return mov_type, mov_desc
+            return mov_type, mov_desc
 
-		case "Delivery Note":
-			voucher_doc = frappe.get_doc("Delivery Note", doc.voucher_no)
-			(
-				mov_type,
-				mov_desc,
-			) = get_item_movement_for_delivery_note_and_sale_invoice_on_submit_and_cancel(
-				doc, voucher_doc
-			)
-			return mov_type, mov_desc
+        case "Delivery Note":
+            voucher_doc = frappe.get_doc("Delivery Note", doc.voucher_no)
+            (
+                mov_type,
+                mov_desc,
+            ) = get_item_movement_for_delivery_note_and_sale_invoice_on_submit_and_cancel(
+                doc, voucher_doc
+            )
+            return mov_type, mov_desc
 
-		case "Sales Invoice":
-			voucher_doc = frappe.get_doc("Sales Invoice", doc.voucher_no)
-			(
-				mov_type,
-				mov_desc,
-			) = get_item_movement_for_delivery_note_and_sale_invoice_on_submit_and_cancel(
-				doc, voucher_doc
-			)
-			return mov_type, mov_desc
+        case "Sales Invoice":
+            voucher_doc = frappe.get_doc("Sales Invoice", doc.voucher_no)
+            (
+                mov_type,
+                mov_desc,
+            ) = get_item_movement_for_delivery_note_and_sale_invoice_on_submit_and_cancel(
+                doc, voucher_doc
+            )
+            return mov_type, mov_desc
 
-		case "Purchase Invoice":
-			voucher_doc = frappe.get_doc("Purchase Invoice", doc.voucher_no)
-			mov_type = get_item_movement_for_purchase_receipt_and_invoice_on_submit_and_cancel(
-				doc, voucher_doc
-			)
-			mov_desc = get_stock_movement_description(voucher_doc)
-			return mov_type, mov_desc
+        case "Purchase Invoice":
+            voucher_doc = frappe.get_doc("Purchase Invoice", doc.voucher_no)
+            mov_type = (
+                get_item_movement_for_purchase_receipt_and_invoice_on_submit_and_cancel(
+                    doc, voucher_doc
+                )
+            )
+            mov_desc = get_stock_movement_description(voucher_doc)
+            return mov_type, mov_desc
 
-		case "Stock Reconciliation":
-			voucher_doc = frappe.get_doc("Stock Reconciliation", doc.voucher_no)
-			mov_type, qty_diff = get_stock_recon_movement_type(doc, voucher_doc)
-			mov_desc = get_stock_movement_description(voucher_doc)
-			return mov_type, qty_diff, mov_desc
+        case "Stock Reconciliation":
+            voucher_doc = frappe.get_doc("Stock Reconciliation", doc.voucher_no)
+            mov_type, qty_diff = get_stock_recon_movement_type(doc, voucher_doc)
+            mov_desc = get_stock_movement_description(voucher_doc)
+            return mov_type, qty_diff, mov_desc
 
-		case "Asset Capitalization":
-			voucher_doc = frappe.get_doc("Asset Capitalization", doc.voucher_no)
-			mov_type = get_item_movement_asset_capitalisation_on_submit_and_cancel(
-				doc, voucher_doc
-			)
-			mov_desc = get_stock_movement_description(voucher_doc)
-			return mov_type, mov_desc
+        case "Asset Capitalization":
+            voucher_doc = frappe.get_doc("Asset Capitalization", doc.voucher_no)
+            mov_type = get_item_movement_asset_capitalisation_on_submit_and_cancel(
+                doc, voucher_doc
+            )
+            mov_desc = get_stock_movement_description(voucher_doc)
+            return mov_type, mov_desc
 
-		case "Asset Repair":
-			voucher_doc = frappe.get_doc("Asset Repair", doc.voucher_no)
-			mov_type = get_item_movement_asset_capitalisation_on_submit_and_cancel(
-				doc, voucher_doc
-			)
-			mov_desc = get_stock_movement_description(voucher_doc)
-			return mov_type, mov_desc
+        case "Asset Repair":
+            voucher_doc = frappe.get_doc("Asset Repair", doc.voucher_no)
+            mov_type = get_item_movement_asset_capitalisation_on_submit_and_cancel(
+                doc, voucher_doc
+            )
+            mov_desc = get_stock_movement_description(voucher_doc)
+            return mov_type, mov_desc
 
-		case _:
-			return None
+        case _:
+            return None
 
 
 def get_stock_movement_type_for_stock_entry(doc, voucher_doc):
-	"""
-	Get the stock movement type based on stock entry type and custom movement type
-	"""
-	entry_type = voucher_doc.stock_entry_type
-	custom_mov_type = voucher_doc.custom_stock_movement_type
+    """
+    Get the stock movement type based on stock entry type and custom movement type
+    """
+    entry_type = frappe.db.get_value(
+        "Stock Entry Type", voucher_doc.stock_entry_type, "purpose"
+    )
+    custom_mov_type = voucher_doc.custom_stock_movement_type
 
-	if (doc.actual_qty > 0 and entry_type in ["Material Receipt", "Manufacture"]) or (
-		doc.actual_qty < 0
-		and entry_type
-		in [
-			"Material Issue",
-			"Material Consumption for Manufacture",
-			"Material Transfer for Manufacture",
-			"Send to Subcontractor",
-		]
-	):
-		return get_stock_movement_on_submit(entry_type, custom_mov_type, voucher_doc)
+    if (doc.actual_qty > 0 and entry_type in ["Material Receipt", "Manufacture"]) or (
+        doc.actual_qty < 0
+        and entry_type
+        in [
+            "Material Issue",
+            "Material Consumption for Manufacture",
+            "Material Transfer for Manufacture",
+            "Send to Subcontractor",
+        ]
+    ):
+        return get_stock_movement_on_submit(entry_type, custom_mov_type, voucher_doc)
 
-	elif (
-		doc.actual_qty < 0
-		and entry_type in ["Material Receipt", "Manufacture"]
-		or doc.actual_qty > 0
-		and entry_type
-		in [
-			"Material Issue",
-			"Material Consumption for Manufacture",
-			"Material Transfer for Manufacture",
-			"Send to Subcontractor",
-		]
-	):
-		return get_stock_movement_on_cancel(entry_type)
+    elif (
+        doc.actual_qty < 0
+        and entry_type in ["Material Receipt", "Manufacture"]
+        or doc.actual_qty > 0
+        and entry_type
+        in [
+            "Material Issue",
+            "Material Consumption for Manufacture",
+            "Material Transfer for Manufacture",
+            "Send to Subcontractor",
+        ]
+    ):
+        return get_stock_movement_on_cancel(entry_type)
 
-	elif entry_type == "Repack":
-		return get_item_movement_for_repack_on_submit_and_cancel(doc, voucher_doc)
+    elif entry_type == "Repack":
+        return get_item_movement_for_repack_on_submit_and_cancel(doc, voucher_doc)
 
 
 def get_stock_movement_on_submit(entry_type, mov_type, voucher_doc):
-	if entry_type == "Material Receipt" and voucher_doc.is_opening == "Yes":
-		return "EI"
-	elif entry_type == "Material Receipt" and voucher_doc.is_opening == "No":
-		return "EAU"
-	elif entry_type == "Material Issue":
-		if mov_type == "Theft exits(SV)":
-			return "SV"
-		elif mov_type == "Obsolete/expired or obsolete issues(SD)":
-			return "SD"
-		elif mov_type == "Breakage Exits(SC)":
-			return "SC"
-		elif mov_type == "Loss Outflows(SP)":
-			return "SP"
-		else:
-			return "ST"
-	elif entry_type == "Manufacture":
-		return "EN"
-	elif entry_type in [
-		"Material Consumption for Manufacture",
-		"Material Transfer for Manufacture",
-		"Send to Subcontractor",
-	]:
-		return "SAU"
-	else:
-		return "EAU"
+    if entry_type == "Material Receipt" and voucher_doc.is_opening == "Yes":
+        return "EI"
+    elif entry_type == "Material Receipt" and voucher_doc.is_opening == "No":
+        return "EAU"
+    elif entry_type == "Material Issue":
+        if mov_type == "Theft exits(SV)":
+            return "SV"
+        elif mov_type == "Obsolete/expired or obsolete issues(SD)":
+            return "SD"
+        elif mov_type == "Breakage Exits(SC)":
+            return "SC"
+        elif mov_type == "Loss Outflows(SP)":
+            return "SP"
+        else:
+            return "ST"
+    elif entry_type == "Manufacture":
+        return "EN"
+    elif entry_type in [
+        "Material Consumption for Manufacture",
+        "Material Transfer for Manufacture",
+        "Send to Subcontractor",
+    ]:
+        return "SAU"
+    else:
+        return "EAU"
 
 
 def get_stock_movement_on_cancel(entry_type):
-	if entry_type == "Material Receipt":
-		return "SAU"
-	elif entry_type == "Material Issue":
-		return "EAU"
-	elif entry_type == "Manufacture":
-		return "SAU"
-	elif entry_type in [
-		"Repack",
-		"Material Consumption for Manufacture",
-		"Material Transfer for Manufacture",
-		"Send to Subcontractor",
-	]:
-		return "ER"
-	else:
-		return "EAU"
+    if entry_type == "Material Receipt":
+        return "SAU"
+    elif entry_type == "Material Issue":
+        return "EAU"
+    elif entry_type == "Manufacture":
+        return "SAU"
+    elif entry_type in [
+        "Repack",
+        "Material Consumption for Manufacture",
+        "Material Transfer for Manufacture",
+        "Send to Subcontractor",
+    ]:
+        return "ER"
+    else:
+        return "EAU"
 
 
 def get_item_movement_for_repack_on_submit_and_cancel(doc, voucher_doc):
-	"""
-	Get the movement type for repack
-	"""
+    """
+    Get the movement type for repack
+    """
 
-	# get the item_code from stock ledger entry
-	item_code = doc.item_code
+    # get the item_code from stock ledger entry
+    item_code = doc.item_code
 
-	for item in voucher_doc.items:
-		if item.item_code == item_code:
-			if doc.actual_qty > 0.0:
-				return "EAU"
-			else:
-				return "SAU"
+    for item in voucher_doc.items:
+        if item.item_code == item_code:
+            if doc.actual_qty > 0.0:
+                return "EAU"
+            else:
+                return "SAU"
 
 
 def get_stock_movement_description(voucher_doc):
-	stock_movement_description = (
-		voucher_doc.custom_stock_movement_description
-		if voucher_doc.custom_stock_movement_description
-		else ""
-	)
-	return stock_movement_description
+    stock_movement_description = (
+        voucher_doc.custom_stock_movement_description
+        if voucher_doc.custom_stock_movement_description
+        else ""
+    )
+    return stock_movement_description
 
 
 def get_item_movement_for_purchase_receipt_and_invoice_on_submit_and_cancel(
-	doc, voucher_doc
+    doc, voucher_doc
 ):
-	"""
-	Get the movement type for purchase receipt
-	"""
-	movement_type = "EN"
-	item_code = doc.item_code
+    """
+    Get the movement type for purchase receipt
+    """
+    movement_type = "EN"
+    item_code = doc.item_code
 
-	for item in voucher_doc.items:
-		if item.item_code == item_code:
-			if doc.actual_qty > 0.0:
-				return movement_type
-			else:
-				movement_type = "SAU"
-				return movement_type
+    for item in voucher_doc.items:
+        if item.item_code == item_code:
+            if doc.actual_qty > 0.0:
+                return movement_type
+            else:
+                movement_type = "SAU"
+                return movement_type
 
 
 def get_item_movement_for_delivery_note_and_sale_invoice_on_submit_and_cancel(
-	doc, voucher_doc
+    doc, voucher_doc
 ):
-	"""
-	Get the movement type for delivery note and sales invoice
-	"""
-	movement_description = _("Normal Sale of Goods")
-	movement_type = "SN"
-	item_code = doc.item_code
+    """
+    Get the movement type for delivery note and sales invoice
+    """
+    movement_description = _("Normal Sale of Goods")
+    movement_type = "SN"
+    item_code = doc.item_code
 
-	for item in voucher_doc.items:
-		if item.item_code == item_code:
-			if doc.actual_qty < 0.0:
-				return movement_type, movement_description
-			else:
-				movement_description = _("Normal Return of goods")
-				movement_type = "ER"
-				return movement_type, movement_description
+    for item in voucher_doc.items:
+        if item.item_code == item_code:
+            if doc.actual_qty < 0.0:
+                return movement_type, movement_description
+            else:
+                movement_description = _("Normal Return of goods")
+                movement_type = "ER"
+                return movement_type, movement_description
 
 
 def get_stock_recon_movement_type(doc, voucher_doc):
-	"""
-	Get the movement type for stock reconciliation
-	"""
-	has_batch = check_if_item_has_batches(doc.item_code)
-	warehouse = doc.warehouse
-	movement_type = ""
-	quantity_difference = 0
+    """
+    Get the movement type for stock reconciliation
+    """
+    has_batch = check_if_item_has_batches(doc.item_code)
+    warehouse = doc.warehouse
+    movement_type = ""
+    quantity_difference = 0
 
-	if voucher_doc.purpose == "Opening Stock":
-		for item in voucher_doc.items:
-			if item.item_code == doc.item_code and item.warehouse == warehouse:
-				quantity_difference = item.quantity_difference
-		if voucher_doc.is_cancelled == 0:
-			movement_type = "EI"  # Opening Stock
-		else:
-			movement_type = "SAU"
+    if voucher_doc.purpose == "Opening Stock":
+        for item in voucher_doc.items:
+            if item.item_code == doc.item_code and item.warehouse == warehouse:
+                quantity_difference = item.quantity_difference
+        if voucher_doc.is_cancelled == 0:
+            movement_type = "EI"  # Opening Stock
+        else:
+            movement_type = "SAU"
 
-	elif voucher_doc.purpose == "Stock Reconciliation":
-		for item in voucher_doc.items:
-			item_batch = None
-			if has_batch:
-				item_batch = get_specified_batch(doc)
+    elif voucher_doc.purpose == "Stock Reconciliation":
+        for item in voucher_doc.items:
+            item_batch = None
+            if has_batch:
+                item_batch = get_specified_batch(doc)
 
-			# Check if item matches the criteria
-			if (
-				item.item_code == doc.item_code
-				and item.warehouse == warehouse
-				and (not has_batch or item.batch_no == item_batch)
-			):
-				quantity_difference = item.quantity_difference
-				is_cancelled = doc.is_cancelled
+            # Check if item matches the criteria
+            if (
+                item.item_code == doc.item_code
+                and item.warehouse == warehouse
+                and (not has_batch or item.batch_no == item_batch)
+            ):
+                quantity_difference = item.quantity_difference
+                is_cancelled = doc.is_cancelled
 
-				if is_cancelled == 0:
-					if float(quantity_difference) > 0.0:
-						movement_type = "EAJ"
-					elif float(quantity_difference) < 0.0:
-						movement_type = "SAJ"
-				elif is_cancelled == 1:
-					if float(quantity_difference) > 0.0:
-						movement_type = "SAJ"
-					elif float(quantity_difference) < 0.0:
-						movement_type = "EAJ"
-				else:
-					movement_type = "SAU"
+                if is_cancelled == 0:
+                    if float(quantity_difference) > 0.0:
+                        movement_type = "EAJ"
+                    elif float(quantity_difference) < 0.0:
+                        movement_type = "SAJ"
+                elif is_cancelled == 1:
+                    if float(quantity_difference) > 0.0:
+                        movement_type = "SAJ"
+                    elif float(quantity_difference) < 0.0:
+                        movement_type = "EAJ"
+                else:
+                    movement_type = "SAU"
 
-	return movement_type, quantity_difference
+    return movement_type, quantity_difference
 
 
 def get_invoice_reference_number(doc):
-	item_invoice_ref = ""
-	if doc.voucher_type == "Purchase Invoice":
-		purchase_doc = frappe.get_doc("Purchase Invoice", doc.voucher_no)
-		item_invoice_ref = purchase_doc.bill_no
-	elif doc.voucher_type == "Sales Invoice":
-		sales_doc = frappe.get_doc("Sales Invoice", doc.voucher_no)
-		item_invoice_ref = sales_doc.name
-	return item_invoice_ref
+    item_invoice_ref = ""
+    if doc.voucher_type == "Purchase Invoice":
+        purchase_doc = frappe.get_doc("Purchase Invoice", doc.voucher_no)
+        item_invoice_ref = purchase_doc.bill_no
+    elif doc.voucher_type == "Sales Invoice":
+        sales_doc = frappe.get_doc("Sales Invoice", doc.voucher_no)
+        item_invoice_ref = sales_doc.name
+    return item_invoice_ref
 
 
 def create_item_designation(specified_doc, item_code):
-	items = specified_doc.items
-	for item in items:
-		item_designation = ""
-		if item.item_code == item_code:
-			item_designation = (
-				item.description
-				if item.description
-				else (f"{item.item_code}-{item.batch_no}" if item.batch_no else item.item_code)
-			)
-			return item_designation
+    items = specified_doc.items
+    for item in items:
+        item_designation = ""
+        if item.item_code == item_code:
+            item_designation = (
+                item.description
+                if item.description
+                else (
+                    f"{item.item_code}-{item.batch_no}"
+                    if item.batch_no
+                    else item.item_code
+                )
+            )
+            return item_designation
 
-	return item_code
+    return item_code
 
 
 def get_specified_batch(specified_doc):
-	# Get the serial and batch bundle linked to the specified document
-	serial_and_batch = specified_doc.serial_and_batch_bundle
+    # Get the serial and batch bundle linked to the specified document
+    serial_and_batch = specified_doc.serial_and_batch_bundle
 
-	# Fetch the Serial and Batch Bundle document
-	serial_and_batch_doc = frappe.get_doc("Serial and Batch Bundle", serial_and_batch)
+    # Fetch the Serial and Batch Bundle document
+    serial_and_batch_doc = frappe.get_doc("Serial and Batch Bundle", serial_and_batch)
 
-	# Get the list of entries (batches) from the Serial and Batch Bundle document
-	batches = serial_and_batch_doc.entries
+    # Get the list of entries (batches) from the Serial and Batch Bundle document
+    batches = serial_and_batch_doc.entries
 
-	# Pick the first entry's batch number
-	if batches:
-		first_batch_no = batches[0].batch_no
-		return first_batch_no
-	else:
-		frappe.throw("No batches found in the specified Serial and Batch Bundle.")
+    # Pick the first entry's batch number
+    if batches:
+        first_batch_no = batches[0].batch_no
+        return first_batch_no
+    else:
+        frappe.throw("No batches found in the specified Serial and Batch Bundle.")
 
 
 def check_if_item_has_batches(item_code):
-	"""
-	Check if the item has batches
-	"""
-	item_doc = frappe.get_doc("Item", item_code)
-	return item_doc.has_batch_no
+    """
+    Check if the item has batches
+    """
+    item_doc = frappe.get_doc("Item", item_code)
+    return item_doc.has_batch_no
 
 
 def get_item_movement_asset_capitalisation_on_submit_and_cancel(doc, voucher_doc):
-	"""
-	Get the movement type for asset capitalisation
-	"""
-	movement_type = "EN"
-	# movement_description="Asset Capitalization"
-	item_code = doc.item_code
+    """
+    Get the movement type for asset capitalisation
+    """
+    movement_type = "EN"
+    # movement_description="Asset Capitalization"
+    item_code = doc.item_code
 
-	for item in voucher_doc.items:
-		if item.item_code == item_code:
-			if doc.actual_qty > 0.0:
-				return movement_type
-			else:
-				# movement_description="Asset De-capitalization"
-				movement_type = "SAU"
-				return movement_type
+    for item in voucher_doc.items:
+        if item.item_code == item_code:
+            if doc.actual_qty > 0.0:
+                return movement_type
+            else:
+                # movement_description="Asset De-capitalization"
+                movement_type = "SAU"
+                return movement_type
 
 
 def get_system_tax_id(doc):
-	settings_doc = frappe.get_doc(SETTINGS_DOCTYPE_NAME, doc.company)
-	return settings_doc.system_identification_given_by_obr
+    settings_doc = frappe.get_doc(SETTINGS_DOCTYPE_NAME, doc.company)
+    return settings_doc.system_identification_given_by_obr


### PR DESCRIPTION
Align OBR stock movement handling with Stock Entry Type "purpose"

Stock movement background job:
- Skip material transfers using Stock Entry Type.purpose instead of comparing the linked type name to the literal "Material Transfer", so custom or renamed Stock Entry Types behave correctly.

Utils:
- Resolve stock entry "entry type" from Stock Entry Type.purpose for movement classification.

Patches:
- Add delete_old_custom_fields patch to remove legacy custom_etracker / custom_differ_submission_to_obr fields from Sales Invoice, POS Invoice, Delivery Note, Purchase Receipt, Purchase Invoice, Stock Reconciliation, and Stock Entry.